### PR TITLE
Backend: Email verification after registration + POST /api/auth/resend-verification/ #74

### DIFF
--- a/startup_gateway/users/migrations/0003_user_email_verification_nonce.py
+++ b/startup_gateway/users/migrations/0003_user_email_verification_nonce.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0002_seed_roles"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="email_verification_nonce",
+            field=models.CharField(max_length=64, blank=True, default=""),
+        ),
+    ]

--- a/startup_gateway/users/models.py
+++ b/startup_gateway/users/models.py
@@ -27,6 +27,7 @@ class User(AbstractUser):
 
     phone = models.CharField(max_length=20, blank=True)
     verified = models.BooleanField(default=False)
+    email_verification_nonce = models.CharField(max_length=64, blank=True, default="")
     created_at = models.DateTimeField(auto_now_add=True)
 
     roles = models.ManyToManyField(

--- a/startup_gateway/users/serializers.py
+++ b/startup_gateway/users/serializers.py
@@ -57,4 +57,10 @@ class RegisterSerializer(serializers.Serializer):
     def create(self, validated_data):
         return register_user(validated_data, user_model=User)
 
+class VerifyEmailSerializer(serializers.Serializer):
+    token = serializers.CharField()
+
+
+class ResendVerificationSerializer(serializers.Serializer):
+    email = serializers.EmailField()
 

--- a/startup_gateway/users/services.py
+++ b/startup_gateway/users/services.py
@@ -1,6 +1,6 @@
-
 import logging
 import uuid
+from django.core.cache import cache
 
 from investors.models import InvestorProfile
 from startups.models import StartupProfile
@@ -19,7 +19,9 @@ User = get_user_model()
 
 def build_email_verification_token(user):
     signer = TimestampSigner(salt="users.email.verify")
-    payload = f"{user.pk}:{user.email.strip().lower()}"
+    user.email_verification_nonce = uuid.uuid4().hex
+    user.save(update_fields=["email_verification_nonce"])
+    payload = f"{user.pk}:{user.email.strip().lower()}:{user.email_verification_nonce}"
     return signer.sign(payload)
 
 
@@ -55,11 +57,17 @@ def verify_email_token(token):
     except (BadSignature, SignatureExpired):
         return None
 
-    try:
-        user_id_str, email = payload.split(":", 1)
-        user_id = int(user_id_str)
-    except (ValueError, AttributeError):
+    parts = payload.split(":", 2)
+    if len(parts) not in (2, 3):
         return None
+
+    try:
+        user_id = int(parts[0])
+    except (ValueError, TypeError):
+        return None
+
+    email = parts[1]
+    nonce = parts[2] if len(parts) == 3 else None
 
     user = User.objects.filter(pk=user_id).first()
     if not user:
@@ -68,12 +76,29 @@ def verify_email_token(token):
     if user.email.strip().lower() != email.strip().lower():
         return None
 
-    if (not user.verified) or (not user.is_active):
+    if nonce is not None:
+        if not user.email_verification_nonce:
+            return None
+        if user.email_verification_nonce != nonce:
+            return None
+
+    update_fields = []
+    if not user.verified:
         user.verified = True
+        update_fields.append("verified")
+    if not user.is_active:
         user.is_active = True
-        user.save(update_fields=["verified", "is_active"])
+        update_fields.append("is_active")
+
+    if nonce is not None:
+        user.email_verification_nonce = ""
+        update_fields.append("email_verification_nonce")
+
+    if update_fields:
+        user.save(update_fields=update_fields)
 
     return user
+
 
 @transaction.atomic
 def register_user(validated_data, user_model):
@@ -117,3 +142,33 @@ def register_user(validated_data, user_model):
 
     return user, True, True
 
+
+def _resend_verification_email_key(email: str) -> str:
+    return f"auth:resend-verification:email:{email}"
+
+
+def _resend_verification_ip_key(ip: str) -> str:
+    return f"auth:resend-verification:ip:{ip}"
+
+
+def is_resend_verification_throttled(email: str, ip: str) -> bool:
+    email = (email or "").strip().lower()
+    ip = (ip or "").strip()
+
+    email_ttl = int(getattr(settings, "EMAIL_VERIFICATION_RESEND_EMAIL_TTL", 60))
+    ip_ttl = int(getattr(settings, "EMAIL_VERIFICATION_RESEND_IP_TTL", 60))
+
+    email_key = _resend_verification_email_key(email) if email else ""
+    ip_key = _resend_verification_ip_key(ip) if ip else ""
+
+    if email_key and cache.get(email_key):
+        return True
+    if ip_key and cache.get(ip_key):
+        return True
+
+    if email_key:
+        cache.set(email_key, 1, timeout=email_ttl)
+    if ip_key:
+        cache.set(ip_key, 1, timeout=ip_ttl)
+
+    return False

--- a/startup_gateway/users/tests.py
+++ b/startup_gateway/users/tests.py
@@ -1,5 +1,8 @@
 from django.contrib.auth import get_user_model
 from django.core import mail
+from django.core.cache import cache
+from django.core.signing import SignatureExpired
+from unittest.mock import patch
 from django.test import override_settings
 from rest_framework.test import APITestCase
 
@@ -187,3 +190,114 @@ class TestVerifyEmailApi(APITestCase):
     def test_verify_email_invalid_token(self):
         resp = self.client.get("/api/auth/verify-email/?token=bad")
         self.assertEqual(resp.status_code, 400)
+        
+    def test_verify_email_post_happy_path(self):
+        payload = {
+            "email": "alice@example.com",
+            "password": "P@ssw0rd!123",
+            "role": "startup",
+            "company_name": "Handmade Co",
+        }
+
+        with self.captureOnCommitCallbacks(execute=True):
+            resp = self.client.post("/api/auth/register/", payload, format="json")
+
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(len(mail.outbox), 1)
+
+        body = mail.outbox[0].body
+        token = body.split("token=", 1)[1].strip()
+
+        verify_resp = self.client.post("/api/auth/verify-email/", {"token": token}, format="json")
+        self.assertEqual(verify_resp.status_code, 200)
+
+        user = User.objects.get(email="alice@example.com")
+        self.assertTrue(user.is_active)
+        self.assertTrue(user.verified)
+
+
+    def test_verify_email_post_single_use(self):
+        payload = {
+            "email": "alice@example.com",
+            "password": "P@ssw0rd!123",
+            "role": "startup",
+            "company_name": "Handmade Co",
+        }
+
+        with self.captureOnCommitCallbacks(execute=True):
+            resp = self.client.post("/api/auth/register/", payload, format="json")
+
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(len(mail.outbox), 1)
+
+        body = mail.outbox[0].body
+        token = body.split("token=", 1)[1].strip()
+
+        first = self.client.post("/api/auth/verify-email/", {"token": token}, format="json")
+        self.assertEqual(first.status_code, 200)
+
+        second = self.client.post("/api/auth/verify-email/", {"token": token}, format="json")
+        self.assertEqual(second.status_code, 400)
+
+        user = User.objects.get(email="alice@example.com")
+        self.assertTrue(user.is_active)
+        self.assertTrue(user.verified)
+
+
+    def test_verify_email_post_expired_token(self):
+        with patch("users.services.TimestampSigner.unsign", side_effect=SignatureExpired("expired")):
+            resp = self.client.post("/api/auth/verify-email/", {"token": "any"}, format="json")
+        self.assertEqual(resp.status_code, 400)
+
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    EMAIL_VERIFICATION_RESEND_EMAIL_TTL=60,
+    EMAIL_VERIFICATION_RESEND_IP_TTL=60,
+)
+class TestResendVerificationApi(APITestCase):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    def test_resend_returns_200_for_non_existing_email(self):
+        resp = self.client.post(
+            "/api/auth/resend-verification/",
+            {"email": "missing@example.com"},
+            format="json",
+            REMOTE_ADDR="10.0.0.1",
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_resend_throttles_multiple_calls(self):
+        user = User.objects.create_user(
+            username="alice",
+            email="alice@example.com",
+            password="P@ssw0rd!123",
+            verified=False,
+            is_active=False,
+        )
+
+        first = self.client.post(
+            "/api/auth/resend-verification/",
+            {"email": "alice@example.com"},
+            format="json",
+            REMOTE_ADDR="10.0.0.1",
+        )
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(len(mail.outbox), 1)
+
+        user.refresh_from_db()
+        nonce_after_first = user.email_verification_nonce
+
+        second = self.client.post(
+            "/api/auth/resend-verification/",
+            {"email": "alice@example.com"},
+            format="json",
+            REMOTE_ADDR="10.0.0.1",
+        )
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(len(mail.outbox), 1)
+
+        user.refresh_from_db()
+        self.assertEqual(user.email_verification_nonce, nonce_after_first)

--- a/startup_gateway/users/urls.py
+++ b/startup_gateway/users/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import RegisterView, VerifyEmailView
+from .views import RegisterView, VerifyEmailView, ResendVerificationView
 
 urlpatterns = [
     path("register/", RegisterView.as_view(), name="auth-register"),
     path("verify-email/", VerifyEmailView.as_view(), name="auth-verify-email"),
+    path("resend-verification/", ResendVerificationView.as_view(), name="auth-resend-verification"),
 ]

--- a/startup_gateway/users/views.py
+++ b/startup_gateway/users/views.py
@@ -1,12 +1,17 @@
 from django.db import transaction
+from django.contrib.auth import get_user_model
+
+
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny
 
+from .serializers import RegisterSerializer, VerifyEmailSerializer, ResendVerificationSerializer
+from .services import send_verification_email, verify_email_token, is_resend_verification_throttled
 
-from .serializers import RegisterSerializer
-from .services import send_verification_email, verify_email_token
+
+User = get_user_model()
 
 class RegisterView(APIView):
     permission_classes = [AllowAny]
@@ -26,9 +31,46 @@ class RegisterView(APIView):
 
 class VerifyEmailView(APIView):
     permission_classes = [AllowAny]
+    
+    def post(self, request):
+        serializer = VerifyEmailSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        token = serializer.validated_data.get("token", "")
+        user = verify_email_token(token)
+        if not user:
+            return Response({"detail": "Invalid or expired token."}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({"detail": "Email verified."}, status=status.HTTP_200_OK)
+
     def get(self, request):
         token = request.query_params.get("token", "")
         user = verify_email_token(token)
         if not user:
             return Response({"detail": "Invalid or expired token."}, status=status.HTTP_400_BAD_REQUEST)
         return Response({"detail": "Email verified."}, status=status.HTTP_200_OK)
+
+
+class ResendVerificationView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        serializer = ResendVerificationSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        email = serializer.validated_data["email"].strip().lower()
+        ip = request.META.get("REMOTE_ADDR", "")
+
+        if is_resend_verification_throttled(email=email, ip=ip):
+            return Response(
+                {"detail": "If the email address is valid, a verification email has been sent."},
+                status=status.HTTP_200_OK,
+            )
+
+        user = User.objects.filter(email__iexact=email).first()
+        if user and not getattr(user, "verified", False):
+            send_verification_email(user)
+
+        return Response(
+            {"detail": "If the email address is valid, a verification email has been sent."},
+            status=status.HTTP_200_OK,
+        )

--- a/startup_gateway/users/views.py
+++ b/startup_gateway/users/views.py
@@ -60,17 +60,29 @@ class ResendVerificationView(APIView):
         email = serializer.validated_data["email"].strip().lower()
         ip = request.META.get("REMOTE_ADDR", "")
 
-        if is_resend_verification_throttled(email=email, ip=ip):
+        if is_resend_verification_throttled(email="", ip=ip):
             return Response(
                 {"detail": "If the email address is valid, a verification email has been sent."},
                 status=status.HTTP_200_OK,
             )
 
         user = User.objects.filter(email__iexact=email).first()
-        if user and not getattr(user, "verified", False):
-            send_verification_email(user)
+        if not user or getattr(user, "verified", False):
+            return Response(
+                {"detail": "If the email address is valid, a verification email has been sent."},
+                status=status.HTTP_200_OK,
+            )
+
+        if is_resend_verification_throttled(email=email, ip=""):
+            return Response(
+                {"detail": "If the email address is valid, a verification email has been sent."},
+                status=status.HTTP_200_OK,
+            )
+
+        send_verification_email(user)
 
         return Response(
             {"detail": "If the email address is valid, a verification email has been sent."},
             status=status.HTTP_200_OK,
         )
+


### PR DESCRIPTION
[Task#74](https://github.com/orgs/ITA-Dnipro/projects/19/views/3?sliceBy%5Bvalue%5D=PavloNaichuk&pane=issue&itemId=149331466&issue=ITA-Dnipro%7CUA-4421%7C74)
- time-limited + single-use verification tokens (nonce)
- activate user on successful verification
- resend verification with email/IP rate limiting
- unit tests for success, expired token, and throttle